### PR TITLE
Switch Precedent to hash set if there's a large number of dependts

### DIFF
--- a/Assisticant.UnitTest/MemoryLeakTest.cs
+++ b/Assisticant.UnitTest/MemoryLeakTest.cs
@@ -43,7 +43,7 @@ namespace Assisticant.UnitTest
             // Custom linked list implementation for dependents: 48.
             // Other optimizations: 40.
             // Removed WeakReferenceToSelf: 20.
-            Assert.AreEqual(20 + ObservablePlatformOffset, end - start);
+            Assert.AreEqual(24 + ObservablePlatformOffset, end - start);
 
             int value = newObservable;
             Assert.AreEqual(42, value);
@@ -67,7 +67,7 @@ namespace Assisticant.UnitTest
             // Other optimizations: 104.
 			// Added WeakReferenceToSelf: 108.
             // Removed WeakReferenceToSelf: 104.
-            Assert.AreEqual(104 + ComputedPlatformOffset, end - start);
+            Assert.AreEqual(108 + ComputedPlatformOffset, end - start);
 
             int value = newComputed;
             Assert.AreEqual(42, value);
@@ -93,7 +93,7 @@ namespace Assisticant.UnitTest
             // Other optimizations: 144.
 			// Added WeakReferenceToSelf: 148.
             // Removed WeakReferenceToSelf: 124.
-			Assert.AreEqual(124 + ObservablePlatformOffset, end - start);
+			Assert.AreEqual(132 + ObservablePlatformOffset, end - start);
 
             int value = newComputed;
             Assert.AreEqual(42, value);

--- a/Assisticant/Assisticant.Portable.csproj
+++ b/Assisticant/Assisticant.Portable.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Fields\Computed.cs" />
     <Compile Include="Fields\Observable.cs" />
     <Compile Include="Fields\ComputedSubscription.cs" />
+    <Compile Include="WeakArray.cs" />
     <Compile Include="Metas\AtomSlot.cs" />
     <Compile Include="Metas\CollectionItem.cs" />
     <Compile Include="Metas\CollectionSlot.cs" />
@@ -114,6 +115,7 @@
     <Compile Include="Timers\UtcTimeZone.cs" />
     <Compile Include="MakeCommand.cs" />
     <Compile Include="UpdateScheduler.cs" />
+    <Compile Include="WeakHashSet.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Assisticant/Assisticant.Universal.csproj
+++ b/Assisticant/Assisticant.Universal.csproj
@@ -103,6 +103,8 @@
     <Compile Include="ViewModelBase.cs" />
     <Compile Include="ViewModelLocatorBase.cs" />
     <Compile Include="ViewSelector.cs" />
+    <Compile Include="WeakArray.cs" />
+    <Compile Include="WeakHashSet.cs" />
     <Compile Include="XamlTypes\PlatformProxy.cs" />
     <Compile Include="XamlTypes\PrimitiveXamlType.cs" />
     <Compile Include="XamlTypes\ProxyXamlMember.cs" />

--- a/Assisticant/WeakArray.cs
+++ b/Assisticant/WeakArray.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace Assisticant
+{
+    static class WeakArray
+    {
+        public static void Add(ref WeakReference[] array, object item)
+        {
+            Debug.Assert(item != null);
+            if (array == null)
+                array = new WeakReference[] { new WeakReference(item) };
+            else
+            {
+                int count = GetCount(ref array);
+                if (count < array.Length)
+                    array[count] = new WeakReference(item);
+                else
+                {
+                    var enlarged = new WeakReference[2 * array.Length];
+                    Array.Copy(array, enlarged, array.Length);
+                    enlarged[array.Length] = new WeakReference(item);
+                    array = enlarged;
+                }
+            }
+        }
+
+        public static void Remove(ref WeakReference[] array, object item)
+        {
+            if (array != null)
+            {
+                int count = 0;
+                for (int i = 0; i < array.Length; ++i)
+                {
+                    if (array[i] == null)
+                        break;
+                    var target = array[i].Target;
+                    if (target != null && target != item)
+                    {
+                        if (i > count)
+                        {
+                            array[count] = array[i];
+                            array[i] = null;
+                        }
+                        ++count;
+                    }
+                    else
+                        array[i] = null;
+                }
+                if (count == 0)
+                    array = null;
+            }
+        }
+
+        public static bool Contains(ref WeakReference[] array, object item)
+        {
+            Debug.Assert(item != null);
+            if (array == null)
+                return false;
+            else
+            {
+                foreach (var reference in array)
+                {
+                    if (reference == null)
+                        break;
+                    if (reference.Target == item)
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        public static int GetCount(ref WeakReference[] array)
+        {
+            if (array == null)
+                return 0;
+            int count = 0;
+            for (int i = 0; i < array.Length; ++i)
+            {
+                if (array[i] == null)
+                    break;
+                if (array[i].IsAlive)
+                {
+                    if (i > count)
+                    {
+                        array[count] = array[i];
+                        array[i] = null;
+                    }
+                    ++count;
+                }
+                else
+                    array[i] = null;
+            }
+            if (count == 0)
+                array = null;
+            return count;
+        }
+
+        public static IEnumerable<T> Enumerate<T>(WeakReference[] array)
+            where T : class
+        {
+            if (array == null)
+                yield break;
+            foreach (var reference in array)
+            {
+                if (reference == null)
+                    break;
+                var target = reference.Target as T;
+                if (target != null)
+                    yield return target;
+            }
+        }
+    }
+}

--- a/Assisticant/WeakHashSet.cs
+++ b/Assisticant/WeakHashSet.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Assisticant
+{
+    class WeakHashSet<T> : IEnumerable<T>
+        where T : class
+    {
+        readonly HashSet<HashedWeakReference> _set = new HashSet<HashedWeakReference>();
+
+        public int Count { get { return _set.Count; } }
+
+        public void Add(T item)
+        {
+            _set.Add(new HashedWeakReference(item));
+        }
+
+        public void Remove(T item)
+        {
+            _set.Remove(new HashedWeakReference(item));
+        }
+
+        public bool Contains(T item)
+        {
+            return _set.Contains(new HashedWeakReference(item));
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() { return GetItems().GetEnumerator(); }
+        IEnumerator IEnumerable.GetEnumerator() { return GetItems().GetEnumerator(); }
+
+        IEnumerable<T> GetItems()
+        {
+            foreach (var reference in _set)
+            {
+                var target = reference.Target as T;
+                if (target != null)
+                    yield return target;
+            }
+        }
+
+        class HashedWeakReference : WeakReference
+        {
+            int _hashCode;
+
+            public HashedWeakReference(object target)
+                : base(target)
+            {
+                _hashCode = target.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                var reference = obj as HashedWeakReference;
+                if (reference == null)
+                    return false;
+                var target1 = Target;
+                var target2 = reference.Target;
+                if (target1 == null || target2 == null)
+                    return false;
+                return Equals(target1, target2);
+            }
+
+            public override int GetHashCode() { return _hashCode; }
+        }
+    }
+}


### PR DESCRIPTION
Additionally, for small number of dependents, Precedent now uses array instead of linked list
