### PR TITLE
Fire PropertyChanged event outside of Computed update method

### DIFF
--- a/Assisticant/Metas/MemberSlot.cs
+++ b/Assisticant/Metas/MemberSlot.cs
@@ -11,17 +11,29 @@ namespace Assisticant.Metas
     {
         public readonly ViewProxy Proxy;
         public readonly MemberMeta Member;
+        readonly Computed _computed;
         public object Instance { get { return Proxy.Instance; } }
 
         protected MemberSlot(ViewProxy proxy, MemberMeta member)
         {
             Proxy = proxy;
             Member = member;
+            if (member.CanRead)
+            {
+                // When the property is out of date, update it from the wrapped object.
+                _computed = new Computed(() => BindingInterceptor.Current.UpdateValue(this));
+                // When the property becomes out of date, trigger an update.
+                // The update should have lower priority than user input & drawing,
+                // to ensure that the app doesn't lock up in case a large model is 
+                // being updated outside the UI (e.g. via timers or the network).
+                _computed.Invalidated += () => UpdateScheduler.ScheduleUpdate(UpdateNow);
+            }
         }
 
         public abstract void SetValue(object value);
         public abstract object GetValue();
         internal abstract void UpdateValue();
+        protected abstract void PublishChanges();
 
         internal static MemberSlot Create(ViewProxy proxy, MemberMeta member)
         {
@@ -55,6 +67,17 @@ namespace Assisticant.Metas
             if (!ViewModelTypes.IsViewModel(value.GetType()))
                 return value;
             return Proxy.WrapObject(value);
+        }
+
+        protected void UpdateNow()
+        {
+            if (_computed.IsNotUpdating)
+            {
+                _computed.OnGet();
+                // Update the GUI outside of the update method
+                // so we don't take a dependency on template bindings.
+                PublishChanges();
+            }
         }
 
         public override string ToString()


### PR DESCRIPTION
This was implemented for CollectionSlot before, but I added similar logic to AtomSlot, because that one can also create accidental dependencies when bound to ContentControl. ContentTemplate in ContentControl gets instantiated during PropertyChanged event, which caused accidental dependencies for AtomSlot. While doing this, I've also moved some shared code from CollectionSlot and AtomSlot up to MemberSlot.
