### PR TITLE
Protect member slots against reentrency.

### DIFF
--- a/Assisticant/Metas/AtomSlot.cs
+++ b/Assisticant/Metas/AtomSlot.cs
@@ -43,7 +43,7 @@ namespace Assisticant.Metas
             _sourceValue = WrapValue(Member.GetValue(Instance));
         }
 
-        protected override void PublishChanges()
+        protected internal override void PublishChanges()
         {
             if (!Object.Equals(_value, _sourceValue))
             {

--- a/Assisticant/Metas/BindingListSlot.cs
+++ b/Assisticant/Metas/BindingListSlot.cs
@@ -78,7 +78,7 @@ namespace Assisticant.Metas
             // getters to fire.
         }
 
-        protected override void PublishChanges()
+        protected internal override void PublishChanges()
         {
             if (_sourceCollection == null)
             {

--- a/Assisticant/Metas/CollectionSlot.cs
+++ b/Assisticant/Metas/CollectionSlot.cs
@@ -67,7 +67,7 @@ namespace Assisticant.Metas
             // getters to fire.
         }
 
-        protected override void PublishChanges()
+        protected internal override void PublishChanges()
         {
             if (_sourceCollection == null)
             {

--- a/Assisticant/Metas/MemberSlot.cs
+++ b/Assisticant/Metas/MemberSlot.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace Assisticant.Metas
@@ -30,7 +29,7 @@ namespace Assisticant.Metas
         public abstract void SetValue(object value);
         public abstract object GetValue();
         internal abstract void UpdateValue();
-        protected abstract void PublishChanges();
+        protected internal abstract void PublishChanges();
 
         internal static MemberSlot Create(ViewProxy proxy, MemberMeta member)
         {
@@ -105,7 +104,7 @@ namespace Assisticant.Metas
 
                 // Update the GUI outside of the update method
                 // so we don't take a dependency on template bindings.
-                PublishChanges();
+                Proxy.Notify(() => PublishChanges());
             }
         }
 

--- a/Assisticant/Metas/PassThroughSlot.cs
+++ b/Assisticant/Metas/PassThroughSlot.cs
@@ -18,7 +18,7 @@ namespace Assisticant.Metas
             return Member.GetValue(Instance);
         }
 
-        protected override void PublishChanges()
+        protected internal override void PublishChanges()
         {
         }
 


### PR DESCRIPTION
Ignore events on the observable collection that we caused ourselves. These are output, not input.
If the control modifies a property because another one is notifying, then notify the modified control later.