### PR TITLE
Implement IReadOnlyList/IReadOnlyDictionary on collections

### DIFF
--- a/Assisticant/Collections/ComputedDictionary.cs
+++ b/Assisticant/Collections/ComputedDictionary.cs
@@ -13,7 +13,7 @@ namespace Assisticant.Collections
 	/// job is to choose the contents of the dictionary (either as a list of key-
 	/// value pairs, or as an object that implements <see cref="IDictionary{TKey,TValue}"/>).
 	/// </remarks>
-	public class ComputedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+	public class ComputedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
 	{
 		private readonly Func<IEnumerable<KeyValuePair<TKey, TValue>>> _computeCollection;
 		private IDictionary<TKey, TValue> _dictionary;
@@ -100,6 +100,7 @@ namespace Assisticant.Collections
 			}
 		}
 		ICollection<TKey> IDictionary<TKey, TValue>.Keys { get { return Keys; } }
+		IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 
 		public bool Remove(TKey key)
 		{
@@ -122,6 +123,7 @@ namespace Assisticant.Collections
 			}
 		}
 		ICollection<TValue> IDictionary<TKey, TValue>.Values { get { return Values; } }
+		IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
 
 		public TValue this[TKey key]
 		{
@@ -195,5 +197,5 @@ namespace Assisticant.Collections
 		{
 			get { return _computedSentry; }
 		}
-	}
+    }
 }

--- a/Assisticant/Collections/ComputedList.cs
+++ b/Assisticant/Collections/ComputedList.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 
 namespace Assisticant.Collections
 {
-    public class ComputedList<T> : IEnumerable<T>
+    public class ComputedList<T> : IEnumerable<T>, IReadOnlyList<T>
     {
         private readonly Func<IEnumerable<T>> _computeCollection;
 

--- a/Assisticant/Collections/ObservableDictionary.cs
+++ b/Assisticant/Collections/ObservableDictionary.cs
@@ -16,7 +16,7 @@ using Assisticant.Collections.Impl;
 
 namespace Assisticant.Collections
 {
-	public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary
+	public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
 	{
 		private IDictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
 		private Observable _indDictionary = new NamedObservable(MemoizedTypeName<ObservableDictionary<TKey, TValue>>.GenericName());
@@ -80,6 +80,9 @@ namespace Assisticant.Collections
                 });
             }
         }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
 
 		public bool Remove(TKey key)
 		{

--- a/Assisticant/Collections/ObservableList.cs
+++ b/Assisticant/Collections/ObservableList.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 
 namespace Assisticant.Collections
 {
-	public class ObservableList<T> : IList<T>, IList
+	public class ObservableList<T> : IList<T>, IList, IReadOnlyList<T>
 	{
         private List<T> _list;
 		private Observable _indList = new NamedObservable(MemoizedTypeName<ObservableList<T>>.GenericName());


### PR DESCRIPTION
I was surprised to see that these interfaces aren't implemented. Assisticant is incompatible with my app architecture without them.

**Note:** I don't have Android/iOS/Portable project types installed and so couldn't verify that the changes are fully nonbreaking.

BTW there is a Assisticant.Netstandard project but I didn't see it on NuGet. Have you considered adding it to NuGet or switching to .NET Standard 2.0/2.1?